### PR TITLE
Replace Direct3D proxy with minimal OpenGL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ includes:
   This version uses [MinHook](https://github.com/TsudaKageyu/minhook)
   instead of manually writing relative jumps; MinHook simplifies
   creation and management of multiple hooks and preserves original
-  function pointers so you can call into the game as needed【202001143219462†L36-L90】.
+  function pointers so you can call into the game as needed.
 
 * **third_party/minhook/** – A vendored copy of the MinHook library.
   Only the source and header files are included; you will need to
@@ -56,7 +56,7 @@ includes:
   disassembly listing for the routine at address `0x004A1F8A` in the
   original game.  The C++ stub simply emits a debug message so that
   you can verify the hook is firing.  Replace the body of this function
-  as you reverse‑engineer the real behaviour【283813931668633†L0-L14】.
+  as you reverse‑engineer the real behaviour.
 
 * **digi_analysis.sln / digi_analysis.vcxproj** – Visual Studio
   solution and project files configured for building a Win32 DLL.
@@ -84,7 +84,7 @@ If you are working on a non‑Windows host, it is possible to build the
 code with MinGW or cross‑compile using a toolchain like
 `x86_64‑w64‑mingw32`, provided you supply Windows headers.  Note
 however that the current entry points use Win32 functions to
-demonstrate functionality【202001143219462†L64-L85】.
+demonstrate functionality.
 
 ## Hooking the original executable
 
@@ -96,4 +96,4 @@ disabling hooks, and it can automatically preserve the original
 function pointers so you can call back into the game when necessary.
 The stub `sub_004A1F8A.cpp` shows how to implement a detour for a new
 function: log or inspect arguments, then invoke the original behaviour
-through the saved pointer【328070431545145†L33-L70】.
+through the saved pointer.

--- a/digi_analysis/digi_table.cpp
+++ b/digi_analysis/digi_table.cpp
@@ -3,7 +3,7 @@
 // Definition of the 4 KiB lookup table used by the reconstructed
 // functions.  In the original digi.exe binary, this table contained
 // values produced from a sine curve and was used for gameplay
-// calculations【433935622783790†L0-L8】.  To keep this repository
+// calculations.  To keep this repository
 // lightweight the table below is initialised to all zeros.  Replace
 // this array with the full sine wave extracted from the game for
 // accurate behaviour.

--- a/digi_analysis/digi_table.h
+++ b/digi_analysis/digi_table.h
@@ -2,7 +2,7 @@
 //
 // Declaration of the 4 KiB lookup table extracted from the original
 // digi.exe.  The definitions live in digi_table.cpp and contain
-// 4096 16‑bit signed integers【952462612456350†L0-L13】.
+// 4096 16‑bit signed integers.
 
 #pragma once
 

--- a/digi_analysis/dllmain.cpp
+++ b/digi_analysis/dllmain.cpp
@@ -1,15 +1,14 @@
-// Proxy DLL for DirectX 8.  When compiled as d3d8.dll and placed in
-// the same directory as the original game, this DLL loads the
-// original implementation (`d3d8_orig.dll`), forwards selected exports
-// and installs our runtime hooks.  It combines the proxy approach
-// demonstrated in the old dllmain with the MinHook‑based hooks used
-// elsewhere in this project.
+// Proxy DLL originally designed to wrap DirectX 8.  This version strips
+// out the Direct3D forwarding code and instead boots a minimal OpenGL
+// context.  The DLL still installs runtime hooks and the No‑CD patch but
+// no longer loads or delegates to the original D3D8 library.
 
 #include <windows.h>
 #include "hooks.h"
 #include "MinHook.h"
 #include <cstdint>
 #include <cstring>
+#include "opengl_utils.h"
 
 // Apply an in‑memory patch to bypass the CD check.  The patch data
 // and offsets were extracted from the original project.  On success
@@ -39,135 +38,9 @@ static void ApplyNoCD() {
         }
     }
 }
-// Handle to the original Direct3D 8 library.  We assume the original
-// has been renamed to D3D8_org.dll and resides alongside this DLL.  The
-// original name used by the game might differ (for example, some builds
-// include an extra "i" in the filename).  To avoid confusion and to
-// match the file included with this project, the proxy always attempts
-// to load "D3D8_org.dll".
-static HMODULE g_d3d8 = nullptr;
-
-// -----------------------------------------------------------------------------
-// Basic OpenGL window creation
-//
-// To aid in porting the renderer while keeping the game functional we
-// optionally create a secondary window with an OpenGL context.  This
-// allows you to experiment with rendering the scene using OpenGL
-// alongside the original Direct3D 8 pipeline.  The window is
-// created on the first call to Direct3DCreate8() and remains open
-// until the process exits.  In a complete implementation you would
-// draw your OpenGL scene every frame and synchronise it with the
-// game state.
-
-static bool g_OpenGLWindowCreated = false;
-static HWND g_hWndGL = nullptr;
-static HGLRC g_hGLRC = nullptr;
-static HDC  g_hDCGL = nullptr;
-
-// Creates a simple Win32 window and initialises an OpenGL context.
-// Returns true on success.  This routine registers a minimal window
-// class, creates the window, selects an appropriate pixel format and
-// binds an OpenGL rendering context.  If any step fails the
-// function silently returns false and no window is shown.  You can
-// enhance error handling as needed.
-static bool CreateOpenGLWindow() {
-    if (g_OpenGLWindowCreated) {
-        return true;
-    }
-    // Register a simple window class.  We use DefWindowProc as the
-    // window procedure since we do not process any messages here.
-    WNDCLASSA wc = {};
-    wc.style         = CS_OWNDC;
-    wc.lpfnWndProc   = DefWindowProcA;
-    wc.hInstance     = GetModuleHandleA(NULL);
-    wc.lpszClassName = "DWOpenGLWindow";
-    if (!RegisterClassA(&wc)) {
-        // The class may already be registered; ignore errors.
-    }
-    // Create the window offscreen initially; you can adjust
-    // dimensions as needed.  WS_OVERLAPPEDWINDOW provides a
-    // resizable window with caption and border.
-    g_hWndGL = CreateWindowExA(0, wc.lpszClassName, "Digimon OpenGL Renderer", WS_OVERLAPPEDWINDOW,
-                               CW_USEDEFAULT, CW_USEDEFAULT, 640, 480,
-                               nullptr, nullptr, wc.hInstance, nullptr);
-    if (!g_hWndGL) {
-        return false;
-    }
-    // Get the device context for the window.  We keep it around for
-    // subsequent buffer swaps.
-    g_hDCGL = GetDC(g_hWndGL);
-    if (!g_hDCGL) {
-        DestroyWindow(g_hWndGL);
-        g_hWndGL = nullptr;
-        return false;
-    }
-    // Choose and set a pixel format compatible with OpenGL.  We
-    // request a 32‑bit RGBA framebuffer with double buffering.  The
-    // PIXELFORMATDESCRIPTOR structure is documented on MSDN.
-    PIXELFORMATDESCRIPTOR pfd = {};
-    pfd.nSize        = sizeof(pfd);
-    pfd.nVersion     = 1;
-    pfd.dwFlags      = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
-    pfd.iPixelType   = PFD_TYPE_RGBA;
-    pfd.cColorBits   = 32;
-    pfd.cDepthBits   = 24;
-    pfd.cStencilBits = 8;
-    pfd.iLayerType   = PFD_MAIN_PLANE;
-    int pf = ChoosePixelFormat(g_hDCGL, &pfd);
-    if (pf == 0) {
-        ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
-        g_hWndGL = nullptr;
-        g_hDCGL = nullptr;
-        return false;
-    }
-    if (!SetPixelFormat(g_hDCGL, pf, &pfd)) {
-        ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
-        g_hWndGL = nullptr;
-        g_hDCGL = nullptr;
-        return false;
-    }
-    // Create the OpenGL rendering context and make it current.
-    g_hGLRC = wglCreateContext(g_hDCGL);
-    if (!g_hGLRC) {
-        ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
-        g_hWndGL = nullptr;
-        g_hDCGL = nullptr;
-        return false;
-    }
-    if (!wglMakeCurrent(g_hDCGL, g_hGLRC)) {
-        wglDeleteContext(g_hGLRC);
-        ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
-        g_hWndGL = nullptr;
-        g_hDCGL = nullptr;
-        g_hGLRC = nullptr;
-        return false;
-    }
-    // Show the window.  At this point the window is visible and the
-    // context is current.  You can now perform OpenGL calls such as
-    // glClear, glViewport, etc.  Here we simply clear the colour
-    // buffer to a distinctive colour to indicate success.
-    ShowWindow(g_hWndGL, SW_SHOW);
-    // Load minimal GL functions via the Windows OpenGL headers.  We
-    // avoid linking against GLEW/GLAD here to keep the example self‑
-    // contained.  The function pointers below are available in
-    // opengl32.lib on Windows XP and later.
-    typedef void (APIENTRY* PFNGLCLEARCOLORPROC)(float, float, float, float);
-    typedef void (APIENTRY* PFNGLCLEARPROC)(unsigned int);
-    PFNGLCLEARCOLORPROC pglClearColor = (PFNGLCLEARCOLORPROC)wglGetProcAddress("glClearColor");
-    PFNGLCLEARPROC      pglClear      = (PFNGLCLEARPROC)wglGetProcAddress("glClear");
-    const unsigned int GL_COLOR_BUFFER_BIT = 0x00004000;
-    if (pglClearColor && pglClear) {
-        pglClearColor(0.1f, 0.2f, 0.3f, 1.0f);
-        pglClear(GL_COLOR_BUFFER_BIT);
-        SwapBuffers(g_hDCGL);
-    }
-    g_OpenGLWindowCreated = true;
-    return true;
-}
+// All OpenGL initialisation lives in opengl_utils.cpp.  This file now
+// focuses purely on setting up hooks and exporting a replacement
+// Direct3DCreate8 entry point.
 
 // -----------------------------------------------------------------------------
 // Custom implementation of Direct3DCreate8
@@ -177,138 +50,55 @@ static bool CreateOpenGLWindow() {
 // with an OpenGL implementation we provide our own exported version of
 // Direct3DCreate8 here.  This function logs that it has been invoked
 // and can perform any initialisation required for an OpenGL context.
-// After performing its work it can either return nullptr (to disable
-// Direct3D entirely) or delegate to the original Direct3DCreate8
-// implementation in D3D8_org.dll.  For now we simply delegate to the
-// original to preserve the game’s existing behaviour.  Replace the
-// delegation with your OpenGL setup code as you port the renderer.
+// After performing its work it returns nullptr to signal that the
+// original Direct3D path is unavailable.  All rendering should be
+// performed via the OpenGL context initialised inside this function.
 
-// Forward declaration of the Direct3D 8 interface.  We avoid pulling
-// in the full d3d8.h header by declaring the type as an opaque
-// struct.  This is sufficient for pointer comparisons and returns.
+// Forward declaration of the Direct3D 8 interface.  We continue to
+// declare it opaquely so callers can compile against this header
+// without the full DirectX SDK.
 struct IDirect3D8;
 
-// Type definition matching the prototype of Direct3DCreate8.  The
-// WINAPİ (__stdcall) calling convention is required on 32‑bit
-// Windows.  The single parameter is the SDK version constant used
-// by the caller to verify binary compatibility.
-using PFN_Direct3DCreate8 = IDirect3D8* (WINAPI*)(UINT);
-
-// Cached pointer to the original Direct3DCreate8 function inside
-// D3D8_org.dll.  We resolve this on first use to avoid repeatedly
-// calling GetProcAddress.
-static PFN_Direct3DCreate8 g_origDirect3DCreate8 = nullptr;
-
-// Exported Direct3DCreate8 replacement.  This function is exported
-// from our DLL under both the decorated and undecorated names via
-// the linker directive above.  It can perform any setup needed for
-// an OpenGL backend and then return an IDirect3D8 pointer if
-// continuing to use the original renderer.  Returning nullptr would
-// signal that Direct3D is unavailable.
-extern "C" __declspec(dllexport) IDirect3D8* WINAPI Direct3DCreate8(UINT sdkVersion) {
+// Exported Direct3DCreate8 replacement.  This function is exported from
+// our DLL under both the decorated and undecorated names via the linker
+// directive above.  It initialises an OpenGL backend and returns nullptr
+// to indicate that the original Direct3D implementation is absent.
+extern "C" __declspec(dllexport) IDirect3D8* WINAPI Direct3DCreate8(UINT /*sdkVersion*/) {
     // Log that our replacement has been called.  Use OutputDebugStringA so
-    // that messages appear in the debugger without popping up a
-    // MessageBox.
-    OutputDebugStringA("Direct3DCreate8 called – consider initialising OpenGL here\n");
-    // On the first invocation create an OpenGL window and context.
-    // Subsequent calls will see g_OpenGLWindowCreated set and skip this.
-    if (!g_OpenGLWindowCreated) {
-        CreateOpenGLWindow();
+    // that messages appear in the debugger without popping up a MessageBox.
+    OutputDebugStringA("Direct3DCreate8 called – OpenGL backend active\n");
+
+    // Initialise the OpenGL context.  If this fails we simply report that
+    // Direct3D is unavailable by returning nullptr.
+    if (!InitOpenGL()) {
+        return nullptr;
     }
-    // If we haven’t loaded the original function yet, do so now.
-    if (!g_origDirect3DCreate8) {
-        if (g_d3d8) {
-            g_origDirect3DCreate8 = reinterpret_cast<PFN_Direct3DCreate8>(
-                GetProcAddress(g_d3d8, "Direct3DCreate8"));
-        }
-    }
-    // If we have an original function, call it to obtain a real
-    // IDirect3D8 interface.  You can remove this call once you
-    // implement your OpenGL renderer and no longer need Direct3D.
-    if (g_origDirect3DCreate8) {
-        return g_origDirect3DCreate8(sdkVersion);
-    }
-    // If the original function is unavailable return nullptr to
-    // indicate failure.  The game should handle this gracefully.
+
+    // No Direct3D implementation is provided; returning nullptr informs the
+    // caller that the traditional Direct3D path is disabled.  All rendering
+    // should now be performed via the OpenGL context created above.
     return nullptr;
 }
 
-// We no longer define function pointer types, global pointers or stub
-// implementations for the Direct3D 8 exports.  Instead we forward
-// these exports directly to the original D3D8_org.dll using linker
-// directives below.  The original library will provide the correct
-// calling conventions and parameter lists, avoiding stack imbalance
-// errors.
-
-// The following linker directives force the exports to be named exactly as
-// expected by the game.  Without these directives, __stdcall functions
-// compiled with __declspec(dllexport) may be decorated (e.g. with
-// `@4` suffix) which prevents the loader from resolving the import.  These
-// directives map the undecorated export names to the corresponding
-// functions defined above.
-// Because these functions use the __stdcall (WINAPI) calling
-// convention, the compiler decorates their symbols as
-// _FunctionName@<bytes>.  To export them under their expected
-// undecorated names we specify the decorated name on the right-hand
-// side.  The numbers reflect the total size of the parameters: each
-// parameter is 4 bytes on x86.  See the Visual C++ documentation
-// for details.
-// Forward the Direct3D 8 exports to the original D3D8_org.dll.  This
-// ensures that calls from the game use the correct calling
-// conventions and parameter lists without us having to re‑declare the
-// signatures.  The first part before the equals sign specifies the
-// export name from this DLL; the second part specifies the target
-// DLL and symbol.  Note that the target DLL name is case‑sensitive in
-// the directive but Windows treats file names case‑insensitively.
-//
-// We intentionally do not forward Direct3DCreate8 here because we
-// provide our own implementation below that can initialise an
-// alternative rendering backend (such as OpenGL) before optionally
-// delegating to the original D3D8 entry point.  See
-// Direct3DCreate8() further down in this file.
-#pragma comment(linker, "/export:DebugSetMute=D3D8_org.DebugSetMute")
-#pragma comment(linker, "/export:ValidatePixelShader=D3D8_org.ValidatePixelShader")
-#pragma comment(linker, "/export:ValidateVertexShader=D3D8_org.ValidateVertexShader")
-// Export our custom Direct3DCreate8 function under its undecorated
-// name.  Without this directive the compiler will export it only
-// under the decorated symbol `_Direct3DCreate8@4`, which will not
-// satisfy the game's import table.  See hooks.cpp for a similar
-// pattern with MinHook detours.
+// Export our custom Direct3DCreate8 function under its undecorated name.
+// Without this directive the compiler will export it only under the
+// decorated symbol `_Direct3DCreate8@4`, which will not satisfy the
+// game's import table.
 #pragma comment(linker, "/export:Direct3DCreate8=_Direct3DCreate8@4")
 
-// DLL entry point.  On process attach we load the original DX8
-// library and resolve the address of Direct3DCreate8.  We also
-// initialise and enable our hooks.  On detach we disable hooks and
-// free the original library.
+// DLL entry point.  On process attach we install hooks and apply the
+// No‑CD patch.  On detach we remove hooks.  The original Direct3D8
+// library is no longer loaded.
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
     switch (fdwReason) {
     case DLL_PROCESS_ATTACH:
-        // Load the original Direct3D 8 library.  Attempt to load
-        // "D3D8_org.dll" (matching the file supplied with this
-        // project).  If this fails, the export stubs will return
-        // ERROR_MOD_NOT_FOUND when called.  Windows file names are
-        // case‑insensitive, so the difference in case is irrelevant.
-        g_d3d8 = LoadLibraryA("D3D8_org.dll");
-        // We intentionally do not resolve any function pointers here.  All
-        // exported Direct3D 8 functions are forwarded directly to
-        // D3D8_org.dll via linker directives.
-        // Install our MinHook‑based detours.  If anything fails here
-        // the hooks simply won't be active.
         InstallHooks();
-        // Apply the NoCD patch to bypass the CD check in the original binary.
         ApplyNoCD();
         break;
     case DLL_PROCESS_DETACH:
-        // Disable all hooks and uninitialise MinHook.
         MH_DisableHook(MH_ALL_HOOKS);
         MH_Uninitialize();
-        // Free the original library if it was loaded.
-        if (g_d3d8) {
-            FreeLibrary(g_d3d8);
-            g_d3d8 = nullptr;
-        }
-        // No function pointers to clear; exports are forwarded via the
-        // linker directives.
+        ShutdownOpenGL();
         break;
     }
     return TRUE;

--- a/digi_analysis/functions.cpp
+++ b/digi_analysis/functions.cpp
@@ -3,7 +3,7 @@
 // This file contains hand‑reconstructed C functions that approximate
 // the behaviour of some of the simple routines at the very beginning
 // of digi.exe.  Each function operates on an integer input and looks
-// up a 16‑bit value in a table extracted from the game binary【640324667076106†L12-L20】.
+// up a 16‑bit value in a table extracted from the game binary.
 //
 // In this updated version the functions at 0x401000 and 0x401020 are
 // implemented using inline x86 assembly.  This more closely mirrors
@@ -57,12 +57,12 @@ extern "C" __declspec(naked) int16_t func_401020(int32_t value) {
     }
 }
 
-// Corresponds to the wrapper at 0x401040 which simply calls 0x401020【640324667076106†L28-L31】.
+// Corresponds to the wrapper at 0x401040 which simply calls 0x401020.
 extern "C" int16_t func_401040(int32_t value) {
     return func_401020(value);
 }
 
-// Corresponds to the wrapper at 0x401050 which simply calls 0x401000【640324667076106†L33-L35】.
+// Corresponds to the wrapper at 0x401050 which simply calls 0x401000.
 extern "C" int16_t func_401050(int32_t value) {
     return func_401000(value);
 }

--- a/digi_analysis/functions.h
+++ b/digi_analysis/functions.h
@@ -11,15 +11,15 @@
 
 // Look up a 16‑bit value in the reconstructed table.  This mirrors
 // the behaviour of the routine at address 0x401000.  The input is
-// masked to 12 bits before indexing into the 4096‑entry table【559098899427678†L11-L18】.
+// masked to 12 bits before indexing into the 4096‑entry table.
 extern "C" int16_t func_401000(int32_t value);
 
 // Adds 0x400 to the input, masks to 12 bits and returns the value
-// from the same table.  Mirrors the routine at 0x401020【559098899427678†L16-L18】.
+// from the same table.  Mirrors the routine at 0x401020.
 extern "C" int16_t func_401020(int32_t value);
 
-// Thin wrapper around func_401020 – originally located at 0x401040【559098899427678†L20-L21】.
+// Thin wrapper around func_401020 – originally located at 0x401040.
 extern "C" int16_t func_401040(int32_t value);
 
-// Thin wrapper around func_401000 – originally located at 0x401050【559098899427678†L20-L23】.
+// Thin wrapper around func_401000 – originally located at 0x401050.
 extern "C" int16_t func_401050(int32_t value);

--- a/digi_analysis/hooks.h
+++ b/digi_analysis/hooks.h
@@ -6,12 +6,12 @@
 //
 // This header declares a single function, `InstallHooks()`, which
 // initialises MinHook and installs all configured detours.  See
-// hooks.cpp for the implementation and README.md for usage details【898396427114781†L2-L14】.
+// hooks.cpp for the implementation and README.md for usage details.
 
 #pragma once
 
 // Install all configured hooks.  Call this function from your DLL's
 // entry point or from an injected initialisation routine.  It is
 // safe to call `InstallHooks()` multiple times; repeated calls will
-// simply re‑apply the same patches【898396427114781†L12-L15】.
+// simply re‑apply the same patches.
 void InstallHooks();

--- a/digi_analysis/main.cpp
+++ b/digi_analysis/main.cpp
@@ -1,13 +1,13 @@
 // Copyright (c) 2025
 //
 // Entry point implementation for the reconstructed project.  This file
-// defines WinMain rather than embedding the original executable bytes【557216968203273†L2-L9】.
+// defines WinMain rather than embedding the original executable bytes.
 // Instead of recreating the binary from data, we focus on compiling
 // real code extracted or reconstructed from digi.exe.  The small
 // table lookup functions live in functions.cpp and the extracted
 // strings are available in strings.cpp.  Additionally, we install
 // hooks using MinHook to redirect selected functions in the original
-// game to our C++ implementations【557216968203273†L6-L10】.
+// game to our C++ implementations.
 
 #include <windows.h>
 #include <string>
@@ -23,7 +23,7 @@
 // Forward declarations for the reconstructed functions.  These
 // declarations match those in functions.h but are repeated here to
 // maintain compatibility with existing source files if functions.h is
-// not included【557216968203273†L22-L29】.
+// not included.
 extern "C" int16_t func_401000(int32_t);
 extern "C" int16_t func_401020(int32_t);
 extern "C" int16_t func_401040(int32_t);
@@ -31,7 +31,7 @@ extern "C" int16_t func_401050(int32_t);
 
 // Simple helper to convert a narrow UTF‑8 string to a wide UTF‑16
 // string.  Win32 functions expect UTF‑16 when dealing with wide
-// strings【557216968203273†L31-L38】.
+// strings.
 static std::wstring ToWString(const std::string &s) {
     int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, NULL, 0);
     std::wstring ws(static_cast<size_t>(n), L'\0');
@@ -39,14 +39,14 @@ static std::wstring ToWString(const std::string &s) {
     return ws;
 }
 
-// The WinMain entry point typical of Win32 GUI applications【557216968203273†L41-L49】.
+// The WinMain entry point typical of Win32 GUI applications.
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow) {
     // Install our hooks before doing anything else.  In a DLL build
-    // this would typically be done from DllMain on process attach【557216968203273†L44-L47】.
+    // this would typically be done from DllMain on process attach.
     InstallHooks();
 
-    // Demonstrate reconstructed functions.  We call each with a few test values【557216968203273†L48-L58】.
+    // Demonstrate reconstructed functions.  We call each with a few test values.
     int inputs[] = {0, 1, 100, 4095, -1};
     std::string message;
     message += "Testing reconstructed functions:\n";
@@ -60,7 +60,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     }
 
     // Show the first few extracted strings in a message box to prove the strings
-    // were correctly decoded.  We limit to a handful to avoid huge dialogs【557216968203273†L61-L64】.
+    // were correctly decoded.  We limit to a handful to avoid huge dialogs.
     message += "\nSample extracted strings:\n";
     std::size_t sampleCount = (g_strings_count < 10) ? g_strings_count : 10;
     for (std::size_t i = 0; i < sampleCount; ++i) {

--- a/digi_analysis/opengl_utils.cpp
+++ b/digi_analysis/opengl_utils.cpp
@@ -1,0 +1,144 @@
+#include "opengl_utils.h"
+#include <GL/gl.h>
+
+namespace {
+    bool   g_OpenGLWindowCreated = false;
+    HWND   g_hWndGL              = nullptr;
+    HGLRC  g_hGLRC               = nullptr;
+    HDC    g_hDCGL               = nullptr;
+    HANDLE g_renderThread        = nullptr;
+    bool   g_running             = false;
+
+    DWORD WINAPI RenderThread(LPVOID) {
+        typedef void (APIENTRY* PFNGLCLEARCOLORPROC)(float, float, float, float);
+        typedef void (APIENTRY* PFNGLCLEARPROC)(unsigned int);
+        PFNGLCLEARCOLORPROC pglClearColor = (PFNGLCLEARCOLORPROC)wglGetProcAddress("glClearColor");
+        PFNGLCLEARPROC      pglClear      = (PFNGLCLEARPROC)wglGetProcAddress("glClear");
+        while (g_running) {
+            MSG msg;
+            while (PeekMessage(&msg, g_hWndGL, 0, 0, PM_REMOVE)) {
+                TranslateMessage(&msg);
+                DispatchMessage(&msg);
+            }
+            if (pglClearColor && pglClear) {
+                pglClearColor(0.1f, 0.2f, 0.3f, 1.0f);
+                pglClear(GL_COLOR_BUFFER_BIT);
+            }
+            SwapBuffers(g_hDCGL);
+            Sleep(16);
+        }
+        return 0;
+    }
+}
+
+bool InitOpenGL() {
+    if (g_OpenGLWindowCreated) {
+        return true;
+    }
+    WNDCLASSA wc = {};
+    wc.style         = CS_OWNDC;
+    wc.lpfnWndProc   = DefWindowProcA;
+    wc.hInstance     = GetModuleHandleA(nullptr);
+    wc.lpszClassName = "DWOpenGLWindow";
+    if (!RegisterClassA(&wc)) {
+        // ignore errors; class may already exist
+    }
+    g_hWndGL = CreateWindowExA(0, wc.lpszClassName, "Digimon OpenGL Renderer", WS_OVERLAPPEDWINDOW,
+                               CW_USEDEFAULT, CW_USEDEFAULT, 640, 480,
+                               nullptr, nullptr, wc.hInstance, nullptr);
+    if (!g_hWndGL) {
+        return false;
+    }
+    g_hDCGL = GetDC(g_hWndGL);
+    if (!g_hDCGL) {
+        DestroyWindow(g_hWndGL);
+        g_hWndGL = nullptr;
+        return false;
+    }
+    PIXELFORMATDESCRIPTOR pfd = {};
+    pfd.nSize        = sizeof(pfd);
+    pfd.nVersion     = 1;
+    pfd.dwFlags      = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+    pfd.iPixelType   = PFD_TYPE_RGBA;
+    pfd.cColorBits   = 32;
+    pfd.cDepthBits   = 24;
+    pfd.cStencilBits = 8;
+    pfd.iLayerType   = PFD_MAIN_PLANE;
+    int pf = ChoosePixelFormat(g_hDCGL, &pfd);
+    if (pf == 0) {
+        ReleaseDC(g_hWndGL, g_hDCGL);
+        DestroyWindow(g_hWndGL);
+        g_hWndGL = nullptr;
+        g_hDCGL = nullptr;
+        return false;
+    }
+    if (!SetPixelFormat(g_hDCGL, pf, &pfd)) {
+        ReleaseDC(g_hWndGL, g_hDCGL);
+        DestroyWindow(g_hWndGL);
+        g_hWndGL = nullptr;
+        g_hDCGL = nullptr;
+        return false;
+    }
+    g_hGLRC = wglCreateContext(g_hDCGL);
+    if (!g_hGLRC) {
+        ReleaseDC(g_hWndGL, g_hDCGL);
+        DestroyWindow(g_hWndGL);
+        g_hWndGL = nullptr;
+        g_hDCGL = nullptr;
+        return false;
+    }
+    if (!wglMakeCurrent(g_hDCGL, g_hGLRC)) {
+        wglDeleteContext(g_hGLRC);
+        ReleaseDC(g_hWndGL, g_hDCGL);
+        DestroyWindow(g_hWndGL);
+        g_hWndGL = nullptr;
+        g_hDCGL = nullptr;
+        g_hGLRC = nullptr;
+        return false;
+    }
+    ShowWindow(g_hWndGL, SW_SHOW);
+
+    g_running = true;
+    g_renderThread = CreateThread(nullptr, 0, RenderThread, nullptr, 0, nullptr);
+    if (!g_renderThread) {
+        g_running = false;
+        wglMakeCurrent(nullptr, nullptr);
+        wglDeleteContext(g_hGLRC);
+        ReleaseDC(g_hWndGL, g_hDCGL);
+        DestroyWindow(g_hWndGL);
+        g_hGLRC = nullptr;
+        g_hDCGL = nullptr;
+        g_hWndGL = nullptr;
+        return false;
+    }
+
+    g_OpenGLWindowCreated = true;
+    return true;
+}
+
+void ShutdownOpenGL() {
+    if (!g_OpenGLWindowCreated) {
+        return;
+    }
+
+    g_running = false;
+    if (g_renderThread) {
+        WaitForSingleObject(g_renderThread, INFINITE);
+        CloseHandle(g_renderThread);
+        g_renderThread = nullptr;
+    }
+    wglMakeCurrent(nullptr, nullptr);
+    if (g_hGLRC) {
+        wglDeleteContext(g_hGLRC);
+        g_hGLRC = nullptr;
+    }
+    if (g_hDCGL && g_hWndGL) {
+        ReleaseDC(g_hWndGL, g_hDCGL);
+        g_hDCGL = nullptr;
+    }
+    if (g_hWndGL) {
+        DestroyWindow(g_hWndGL);
+        g_hWndGL = nullptr;
+    }
+    g_OpenGLWindowCreated = false;
+}

--- a/digi_analysis/opengl_utils.h
+++ b/digi_analysis/opengl_utils.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <windows.h>
+
+// Initializes a simple OpenGL window and context.
+// Returns true on success, false on failure.
+bool InitOpenGL();
+
+// Tears down the OpenGL context and associated resources.
+void ShutdownOpenGL();
+

--- a/digi_analysis/strings.cpp
+++ b/digi_analysis/strings.cpp
@@ -5,14 +5,14 @@
 // should contain every string extracted from the game binary, stored
 // as UTF‑16 (wchar_t) string literals.  To keep this demonstration
 // lightweight, a subset of the original strings is provided.  Replace
-// the contents with the full data set for accurate behaviour【183865640345129†L0-L7】.
+// the contents with the full data set for accurate behaviour.
 
 #include "strings.h"
 
 // A sample array of strings extracted from the game.  UTF‑16 literals
 // are prefixed with `L`.  The full list in the original project
 // contained hundreds of entries; only the first few are included here
-// as an example【183865640345129†L11-L14】.
+// as an example.
 const wchar_t* g_strings[] = {
     L"낅Q맘?",
     L"D0>A",
@@ -66,5 +66,5 @@ const wchar_t* g_strings[] = {
 };
 
 // Compute the number of strings at compile time.  Using constexpr
-// ensures this value is known at build time and avoids mismatches【183865640345129†L67-L69】.
+// ensures this value is known at build time and avoids mismatches.
 const std::size_t g_strings_count = sizeof(g_strings) / sizeof(g_strings[0]);

--- a/digi_analysis/strings.h
+++ b/digi_analysis/strings.h
@@ -3,7 +3,7 @@
 // Declarations for the wide string table extracted from the Digimon
 // World PC executable.  The definitions live in strings.cpp.  The
 // strings are stored as UTF‑16 (wchar_t) constants because the PC
-// port contains a mixture of Korean and high‑ASCII characters【4574028794943†L2-L6】.
+// port contains a mixture of Korean and high‑ASCII characters.
 
 #pragma once
 
@@ -12,10 +12,10 @@
 
 // Pointer to an array of wide C‑strings containing text extracted
 // directly from digi.exe.  The actual definitions live in
-// strings.cpp【4574028794943†L11-L14】.
+// strings.cpp.
 extern const wchar_t* g_strings[];
 
 // The number of entries in g_strings.  You can compute this at build
 // time by taking sizeof(g_strings)/sizeof(g_strings[0]) in
-// strings.cpp【4574028794943†L17-L19】.
+// strings.cpp.
 extern const std::size_t g_strings_count;

--- a/digi_analysis/sub_004A1F8A.cpp
+++ b/digi_analysis/sub_004A1F8A.cpp
@@ -4,7 +4,7 @@
 // original Digimon World PC executable.  Until this function is fully
 // reverse‑engineered, it simply emits a debug message so that you can
 // verify the hook is firing.  Once the real behaviour is known, feel
-// free to replace the body of this function with your reconstruction【283813931668633†L0-L14】.
+// free to replace the body of this function with your reconstruction.
 
 #include <windows.h>
 #include <cstdio>


### PR DESCRIPTION
## Summary
- remove Direct3D8 forwarding code and load an OpenGL context instead
- centralise OpenGL window creation in `opengl_utils`
- simplify `DllMain` to only install hooks and the No-CD patch
- add a background OpenGL render loop and shutdown cleanup
- clean up comments and fix `RenderText` hook typedef
- ensure `__fastcall` text-surface hooks include a placeholder for the unused EDX register

## Testing
- `apt-get install -y g++-mingw-w64-i686`
- `i686-w64-mingw32-g++ -std=c++17 -c digi_analysis/opengl_utils.cpp -Ithird_party/minhook/include -o /tmp/opengl_utils.o`
- `i686-w64-mingw32-g++ -std=c++17 -c digi_analysis/dllmain.cpp -Ithird_party/minhook/include -o /tmp/dllmain.o`
- `i686-w64-mingw32-g++ -std=c++17 -c digi_analysis/hooks.cpp -Ithird_party/minhook/include -o /tmp/hooks.o`
- `i686-w64-mingw32-g++ -std=c++17 -c digi_analysis/gdi_hooks.cpp -Ithird_party/minhook/include -o /tmp/gdi_hooks.o`


------
https://chatgpt.com/codex/tasks/task_e_688adc86c71c832f839261bcf249fe4f