### PR TITLE
Use game window for OpenGL context

### DIFF
--- a/digi_analysis/opengl_utils.cpp
+++ b/digi_analysis/opengl_utils.cpp
@@ -1,24 +1,62 @@
+// Utility for handling OpenGL rendering within the game's window.
+
 #include "opengl_utils.h"
 #include <GL/gl.h>
 
 namespace {
-    bool   g_OpenGLWindowCreated = false;
-    HWND   g_hWndGL              = nullptr;
-    HGLRC  g_hGLRC               = nullptr;
-    HDC    g_hDCGL               = nullptr;
-    HANDLE g_renderThread        = nullptr;
-    bool   g_running             = false;
+    bool    g_OpenGLWindowCreated = false;
+    HWND    g_hWndGL              = nullptr;
+    WNDPROC g_originalWndProc     = nullptr;
+    HGLRC   g_hGLRC               = nullptr;
+    HDC     g_hDCGL               = nullptr;
+    HANDLE  g_renderThread        = nullptr;
+    bool    g_running             = false;
+    int     g_width               = 0;
+    int     g_height              = 0;
+    bool    g_resizePending       = false;
+
+    BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+        DWORD pid = 0;
+        GetWindowThreadProcessId(hwnd, &pid);
+        if (pid == GetCurrentProcessId() && GetWindow(hwnd, GW_OWNER) == nullptr) {
+            *reinterpret_cast<HWND*>(lParam) = hwnd;
+            return FALSE; // stop enumeration
+        }
+        return TRUE;
+    }
+
+    HWND FindGameWindow() {
+        HWND hwnd = nullptr;
+        EnumWindows(EnumWindowsProc, reinterpret_cast<LPARAM>(&hwnd));
+        return hwnd;
+    }
+
+    LRESULT CALLBACK HookWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+        switch (msg) {
+            case WM_SIZE:
+                g_width         = LOWORD(lParam);
+                g_height        = HIWORD(lParam);
+                g_resizePending = true;
+                break;
+            case WM_CLOSE:
+                g_running = false;
+                break;
+        }
+        return CallWindowProcA(g_originalWndProc, hwnd, msg, wParam, lParam);
+    }
 
     DWORD WINAPI RenderThread(LPVOID) {
+        wglMakeCurrent(g_hDCGL, g_hGLRC);
         typedef void (APIENTRY* PFNGLCLEARCOLORPROC)(float, float, float, float);
         typedef void (APIENTRY* PFNGLCLEARPROC)(unsigned int);
+        typedef void (APIENTRY* PFNGLVIEWPORTPROC)(int, int, int, int);
         PFNGLCLEARCOLORPROC pglClearColor = (PFNGLCLEARCOLORPROC)wglGetProcAddress("glClearColor");
         PFNGLCLEARPROC      pglClear      = (PFNGLCLEARPROC)wglGetProcAddress("glClear");
+        PFNGLVIEWPORTPROC   pglViewport   = (PFNGLVIEWPORTPROC)wglGetProcAddress("glViewport");
         while (g_running) {
-            MSG msg;
-            while (PeekMessage(&msg, g_hWndGL, 0, 0, PM_REMOVE)) {
-                TranslateMessage(&msg);
-                DispatchMessage(&msg);
+            if (g_resizePending && pglViewport) {
+                pglViewport(0, 0, g_width, g_height);
+                g_resizePending = false;
             }
             if (pglClearColor && pglClear) {
                 pglClearColor(0.1f, 0.2f, 0.3f, 1.0f);
@@ -27,6 +65,7 @@ namespace {
             SwapBuffers(g_hDCGL);
             Sleep(16);
         }
+        wglMakeCurrent(nullptr, nullptr);
         return 0;
     }
 }
@@ -35,26 +74,18 @@ bool InitOpenGL() {
     if (g_OpenGLWindowCreated) {
         return true;
     }
-    WNDCLASSA wc = {};
-    wc.style         = CS_OWNDC;
-    wc.lpfnWndProc   = DefWindowProcA;
-    wc.hInstance     = GetModuleHandleA(nullptr);
-    wc.lpszClassName = "DWOpenGLWindow";
-    if (!RegisterClassA(&wc)) {
-        // ignore errors; class may already exist
-    }
-    g_hWndGL = CreateWindowExA(0, wc.lpszClassName, "Digimon OpenGL Renderer", WS_OVERLAPPEDWINDOW,
-                               CW_USEDEFAULT, CW_USEDEFAULT, 640, 480,
-                               nullptr, nullptr, wc.hInstance, nullptr);
+
+    g_hWndGL = FindGameWindow();
     if (!g_hWndGL) {
         return false;
     }
+
     g_hDCGL = GetDC(g_hWndGL);
     if (!g_hDCGL) {
-        DestroyWindow(g_hWndGL);
         g_hWndGL = nullptr;
         return false;
     }
+
     PIXELFORMATDESCRIPTOR pfd = {};
     pfd.nSize        = sizeof(pfd);
     pfd.nVersion     = 1;
@@ -67,45 +98,41 @@ bool InitOpenGL() {
     int pf = ChoosePixelFormat(g_hDCGL, &pfd);
     if (pf == 0) {
         ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
         g_hWndGL = nullptr;
         g_hDCGL = nullptr;
         return false;
     }
     if (!SetPixelFormat(g_hDCGL, pf, &pfd)) {
         ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
         g_hWndGL = nullptr;
         g_hDCGL = nullptr;
         return false;
     }
+
     g_hGLRC = wglCreateContext(g_hDCGL);
     if (!g_hGLRC) {
         ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
         g_hWndGL = nullptr;
         g_hDCGL = nullptr;
         return false;
     }
-    if (!wglMakeCurrent(g_hDCGL, g_hGLRC)) {
-        wglDeleteContext(g_hGLRC);
-        ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
-        g_hWndGL = nullptr;
-        g_hDCGL = nullptr;
-        g_hGLRC = nullptr;
-        return false;
-    }
-    ShowWindow(g_hWndGL, SW_SHOW);
 
-    g_running = true;
+    RECT rc;
+    GetClientRect(g_hWndGL, &rc);
+    g_width         = rc.right - rc.left;
+    g_height        = rc.bottom - rc.top;
+    g_resizePending = true;
+
+    g_originalWndProc = (WNDPROC)SetWindowLongPtrA(g_hWndGL, GWLP_WNDPROC, (LONG_PTR)HookWndProc);
+
+    g_running      = true;
     g_renderThread = CreateThread(nullptr, 0, RenderThread, nullptr, 0, nullptr);
     if (!g_renderThread) {
         g_running = false;
-        wglMakeCurrent(nullptr, nullptr);
         wglDeleteContext(g_hGLRC);
         ReleaseDC(g_hWndGL, g_hDCGL);
-        DestroyWindow(g_hWndGL);
+        SetWindowLongPtrA(g_hWndGL, GWLP_WNDPROC, (LONG_PTR)g_originalWndProc);
+        g_originalWndProc = nullptr;
         g_hGLRC = nullptr;
         g_hDCGL = nullptr;
         g_hWndGL = nullptr;
@@ -127,7 +154,12 @@ void ShutdownOpenGL() {
         CloseHandle(g_renderThread);
         g_renderThread = nullptr;
     }
-    wglMakeCurrent(nullptr, nullptr);
+
+    if (g_originalWndProc && g_hWndGL) {
+        SetWindowLongPtrA(g_hWndGL, GWLP_WNDPROC, (LONG_PTR)g_originalWndProc);
+        g_originalWndProc = nullptr;
+    }
+
     if (g_hGLRC) {
         wglDeleteContext(g_hGLRC);
         g_hGLRC = nullptr;
@@ -136,9 +168,7 @@ void ShutdownOpenGL() {
         ReleaseDC(g_hWndGL, g_hDCGL);
         g_hDCGL = nullptr;
     }
-    if (g_hWndGL) {
-        DestroyWindow(g_hWndGL);
-        g_hWndGL = nullptr;
-    }
+
+    g_hWndGL              = nullptr;
     g_OpenGLWindowCreated = false;
 }


### PR DESCRIPTION
## Summary
- Attach OpenGL context to the game's main window instead of creating a dummy window
- Hook the game's window procedure to react to resize and close events and update the viewport
- Clean up OpenGL resources without destroying the game window

## Testing
- `x86_64-w64-mingw32-g++ -c digi_analysis/opengl_utils.cpp -I/usr/x86_64-w64-mingw32/include -L/usr/x86_64-w64-mingw32/lib -lopengl32 -lgdi32 -o /tmp/opengl_utils.o`


------
https://chatgpt.com/codex/tasks/task_e_688af28ef538832f9671c938ac740fa4