### PR TITLE
Hook Direct3D draw path to OpenGL renderer

### DIFF
--- a/digi_analysis/d3d_capture.cpp
+++ b/digi_analysis/d3d_capture.cpp
@@ -1,0 +1,145 @@
+#include "d3d_capture.h"
+#include "opengl_utils.h"
+#include "MinHook.h"
+#include <vector>
+#include <mutex>
+
+// Original CreateDevice pointer.
+using PFN_CreateDevice = HRESULT (WINAPI*)(IDirect3D8*, UINT, D3DDEVTYPE, HWND, DWORD,
+                                          D3DPRESENT_PARAMETERS*, IDirect3DDevice8**);
+static PFN_CreateDevice s_origCreateDevice = nullptr;
+
+// Device level hooks
+using PFN_DrawIndexedPrimitive = HRESULT (WINAPI*)(IDirect3DDevice8*, D3DPRIMITIVETYPE,
+                                                   UINT, UINT, UINT, UINT);
+using PFN_SetStreamSource = HRESULT (WINAPI*)(IDirect3DDevice8*, UINT, IDirect3DVertexBuffer8*, UINT);
+using PFN_SetIndices = HRESULT (WINAPI*)(IDirect3DDevice8*, IDirect3DIndexBuffer8*, UINT);
+using PFN_SetTexture = HRESULT (WINAPI*)(IDirect3DDevice8*, DWORD, IDirect3DBaseTexture8*);
+using PFN_Present = HRESULT (WINAPI*)(IDirect3DDevice8*, const RECT*, const RECT*, HWND, const RGNDATA*);
+
+static PFN_DrawIndexedPrimitive s_origDrawIndexedPrimitive = nullptr;
+static PFN_SetStreamSource      s_origSetStreamSource      = nullptr;
+static PFN_SetIndices          s_origSetIndices           = nullptr;
+static PFN_SetTexture          s_origSetTexture           = nullptr;
+static PFN_Present             s_origPresent              = nullptr;
+
+static IDirect3DVertexBuffer8* g_currentVB = nullptr;
+static UINT                    g_stride   = 0;
+static IDirect3DIndexBuffer8*  g_currentIB = nullptr;
+static IDirect3DBaseTexture8*  g_currentTex = nullptr;
+
+static HRESULT WINAPI Hook_SetStreamSource(IDirect3DDevice8* device, UINT stream,
+                                           IDirect3DVertexBuffer8* vb, UINT stride) {
+    if (stream == 0) {
+        if (g_currentVB) g_currentVB->Release();
+        g_currentVB = vb;
+        g_stride    = stride;
+        if (g_currentVB) g_currentVB->AddRef();
+    }
+    return s_origSetStreamSource(device, stream, vb, stride);
+}
+
+static HRESULT WINAPI Hook_SetIndices(IDirect3DDevice8* device, IDirect3DIndexBuffer8* ib, UINT base) {
+    (void)base;
+    if (g_currentIB) g_currentIB->Release();
+    g_currentIB = ib;
+    if (g_currentIB) g_currentIB->AddRef();
+    return s_origSetIndices(device, ib, base);
+}
+
+static HRESULT WINAPI Hook_SetTexture(IDirect3DDevice8* device, DWORD stage, IDirect3DBaseTexture8* tex) {
+    if (stage == 0) {
+        if (g_currentTex) g_currentTex->Release();
+        g_currentTex = tex;
+        if (g_currentTex) g_currentTex->AddRef();
+    }
+    return s_origSetTexture(device, stage, tex);
+}
+
+static HRESULT WINAPI Hook_DrawIndexedPrimitive(IDirect3DDevice8* device, D3DPRIMITIVETYPE type,
+                                                UINT minIndex, UINT numVertices, UINT startIndex, UINT primCount) {
+    if (type == D3DPT_TRIANGLELIST && g_currentVB && g_currentIB) {
+        std::vector<float> vertices(numVertices * 5);
+        std::vector<uint16_t> indices(primCount * 3);
+
+        BYTE* vdata = nullptr;
+        if (SUCCEEDED(g_currentVB->Lock(minIndex * g_stride, numVertices * g_stride, &vdata, D3DLOCK_READONLY))) {
+            for (UINT i = 0; i < numVertices; ++i) {
+                float* src = reinterpret_cast<float*>(vdata + i * g_stride);
+                vertices[i * 5 + 0] = src[0];
+                vertices[i * 5 + 1] = src[1];
+                vertices[i * 5 + 2] = src[2];
+                vertices[i * 5 + 3] = src[3];
+                vertices[i * 5 + 4] = src[4];
+            }
+            g_currentVB->Unlock();
+        }
+
+        BYTE* idata = nullptr;
+        UINT indexCount = primCount * 3;
+        if (SUCCEEDED(g_currentIB->Lock(startIndex * sizeof(uint16_t), indexCount * sizeof(uint16_t), &idata, D3DLOCK_READONLY))) {
+            memcpy(indices.data(), idata, indexCount * sizeof(uint16_t));
+            g_currentIB->Unlock();
+        }
+
+        std::vector<uint32_t> texture;
+        UINT texW = 0, texH = 0;
+        if (g_currentTex) {
+            IDirect3DTexture8* tex = static_cast<IDirect3DTexture8*>(g_currentTex);
+            D3DSURFACE_DESC desc;
+            if (SUCCEEDED(tex->GetLevelDesc(0, &desc))) {
+                texW = desc.Width;
+                texH = desc.Height;
+                D3DLOCKED_RECT lr;
+                if (SUCCEEDED(tex->LockRect(0, &lr, nullptr, D3DLOCK_READONLY))) {
+                    texture.resize(texW * texH);
+                    memcpy(texture.data(), lr.pBits, texW * texH * 4);
+                    tex->UnlockRect(0);
+                }
+            }
+        }
+
+        SubmitMesh(vertices.data(), numVertices, indices.data(), indexCount,
+                   texture.empty() ? nullptr : texture.data(), texW, texH);
+    }
+    return s_origDrawIndexedPrimitive(device, type, minIndex, numVertices, startIndex, primCount);
+}
+
+static HRESULT WINAPI Hook_Present(IDirect3DDevice8* device, const RECT* src, const RECT* dst,
+                                   HWND hwnd, const RGNDATA* dirty) {
+    // Allow the original Present to run so the game continues as normal.
+    return s_origPresent(device, src, dst, hwnd, dirty);
+}
+
+static HRESULT WINAPI Hook_CreateDevice(IDirect3D8* d3d, UINT adapter, D3DDEVTYPE deviceType,
+                                        HWND hWnd, DWORD flags, D3DPRESENT_PARAMETERS* params,
+                                        IDirect3DDevice8** outDevice) {
+    HRESULT hr = s_origCreateDevice(d3d, adapter, deviceType, hWnd, flags, params, outDevice);
+    if (SUCCEEDED(hr) && outDevice && *outDevice) {
+        void** vtbl = *reinterpret_cast<void***>(*outDevice);
+        MH_CreateHook(vtbl[71], reinterpret_cast<void*>(&Hook_DrawIndexedPrimitive),
+                      reinterpret_cast<void**>(&s_origDrawIndexedPrimitive));
+        MH_CreateHook(vtbl[83], reinterpret_cast<void*>(&Hook_SetStreamSource),
+                      reinterpret_cast<void**>(&s_origSetStreamSource));
+        MH_CreateHook(vtbl[85], reinterpret_cast<void*>(&Hook_SetIndices),
+                      reinterpret_cast<void**>(&s_origSetIndices));
+        MH_CreateHook(vtbl[61], reinterpret_cast<void*>(&Hook_SetTexture),
+                      reinterpret_cast<void**>(&s_origSetTexture));
+        MH_CreateHook(vtbl[15], reinterpret_cast<void*>(&Hook_Present),
+                      reinterpret_cast<void**>(&s_origPresent));
+        MH_EnableHook(vtbl[71]);
+        MH_EnableHook(vtbl[83]);
+        MH_EnableHook(vtbl[85]);
+        MH_EnableHook(vtbl[61]);
+        MH_EnableHook(vtbl[15]);
+    }
+    return hr;
+}
+
+void InstallD3DCreateDeviceHook(IDirect3D8* d3d) {
+    if (!d3d) return;
+    void** vtbl = *reinterpret_cast<void***>(d3d);
+    MH_CreateHook(vtbl[16], reinterpret_cast<void*>(&Hook_CreateDevice),
+                  reinterpret_cast<void**>(&s_origCreateDevice));
+    MH_EnableHook(vtbl[16]);
+}

--- a/digi_analysis/d3d_capture.h
+++ b/digi_analysis/d3d_capture.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <d3d8.h>
+
+// Install a hook on IDirect3D8::CreateDevice so that we can intercept
+// device creation and patch the resulting IDirect3DDevice8 vtable.
+void InstallD3DCreateDeviceHook(IDirect3D8* d3d);

--- a/digi_analysis/opengl_utils.cpp
+++ b/digi_analysis/opengl_utils.cpp
@@ -1,6 +1,9 @@
 #include "opengl_utils.h"
+#define GL_GLEXT_PROTOTYPES
 #include <GL/gl.h>
-
+#include <GL/glext.h>
+#include <vector>
+#include <mutex>
 namespace {
     bool   g_OpenGLWindowCreated = false;
     HWND   g_hWndGL              = nullptr;
@@ -9,21 +12,96 @@ namespace {
     HANDLE g_renderThread        = nullptr;
     bool   g_running             = false;
 
+    struct MeshData {
+        std::vector<float>     vertices;
+        std::vector<uint16_t>  indices;
+        std::vector<uint32_t>  texture;
+        int                    texWidth  = 0;
+        int                    texHeight = 0;
+        GLuint                 vbo       = 0;
+        GLuint                 ibo       = 0;
+        GLuint                 tex       = 0;
+        bool                   dirty     = false;
+    };
+
+    MeshData g_mesh;
+    std::mutex g_meshMutex;
+
+    void UploadMeshIfNeeded() {
+        if (!g_mesh.dirty) {
+            return;
+        }
+        if (!g_mesh.vbo) {
+            glGenBuffers(1, &g_mesh.vbo);
+        }
+        glBindBuffer(GL_ARRAY_BUFFER, g_mesh.vbo);
+        glBufferData(GL_ARRAY_BUFFER, g_mesh.vertices.size() * sizeof(float),
+                     g_mesh.vertices.data(), GL_STATIC_DRAW);
+
+        if (!g_mesh.ibo) {
+            glGenBuffers(1, &g_mesh.ibo);
+        }
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_mesh.ibo);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, g_mesh.indices.size() * sizeof(uint16_t),
+                     g_mesh.indices.data(), GL_STATIC_DRAW);
+
+        if (g_mesh.texture.size()) {
+            if (!g_mesh.tex) {
+                glGenTextures(1, &g_mesh.tex);
+                glBindTexture(GL_TEXTURE_2D, g_mesh.tex);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+            } else {
+                glBindTexture(GL_TEXTURE_2D, g_mesh.tex);
+            }
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, g_mesh.texWidth, g_mesh.texHeight,
+                         0, GL_BGRA_EXT, GL_UNSIGNED_BYTE, g_mesh.texture.data());
+        }
+
+        g_mesh.dirty = false;
+    }
+
     DWORD WINAPI RenderThread(LPVOID) {
         typedef void (APIENTRY* PFNGLCLEARCOLORPROC)(float, float, float, float);
         typedef void (APIENTRY* PFNGLCLEARPROC)(unsigned int);
         PFNGLCLEARCOLORPROC pglClearColor = (PFNGLCLEARCOLORPROC)wglGetProcAddress("glClearColor");
         PFNGLCLEARPROC      pglClear      = (PFNGLCLEARPROC)wglGetProcAddress("glClear");
+
         while (g_running) {
             MSG msg;
             while (PeekMessage(&msg, g_hWndGL, 0, 0, PM_REMOVE)) {
                 TranslateMessage(&msg);
                 DispatchMessage(&msg);
             }
+
             if (pglClearColor && pglClear) {
                 pglClearColor(0.1f, 0.2f, 0.3f, 1.0f);
                 pglClear(GL_COLOR_BUFFER_BIT);
             }
+
+            {
+                std::lock_guard<std::mutex> lock(g_meshMutex);
+                UploadMeshIfNeeded();
+                if (g_mesh.vbo && g_mesh.ibo && g_mesh.indices.size()) {
+                    glEnable(GL_TEXTURE_2D);
+                    if (g_mesh.tex) {
+                        glBindTexture(GL_TEXTURE_2D, g_mesh.tex);
+                    }
+                    glBindBuffer(GL_ARRAY_BUFFER, g_mesh.vbo);
+                    glVertexPointer(3, GL_FLOAT, 5 * sizeof(float), 0);
+                    glTexCoordPointer(2, GL_FLOAT, 5 * sizeof(float), (const void*)(3 * sizeof(float)));
+                    glEnableClientState(GL_VERTEX_ARRAY);
+                    glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+
+                    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_mesh.ibo);
+                    glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(g_mesh.indices.size()),
+                                   GL_UNSIGNED_SHORT, 0);
+
+                    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+                    glDisableClientState(GL_VERTEX_ARRAY);
+                }
+            }
+
             SwapBuffers(g_hDCGL);
             Sleep(16);
         }
@@ -41,7 +119,7 @@ bool InitOpenGL() {
     wc.hInstance     = GetModuleHandleA(nullptr);
     wc.lpszClassName = "DWOpenGLWindow";
     if (!RegisterClassA(&wc)) {
-        // ignore errors; class may already exist
+        // class may already exist
     }
     g_hWndGL = CreateWindowExA(0, wc.lpszClassName, "Digimon OpenGL Renderer", WS_OVERLAPPEDWINDOW,
                                CW_USEDEFAULT, CW_USEDEFAULT, 640, 480,
@@ -116,6 +194,20 @@ bool InitOpenGL() {
     return true;
 }
 
+void SubmitMesh(const float* vertices, size_t vertexCount,
+                const uint16_t* indices, size_t indexCount,
+                const uint32_t* texture, int texWidth, int texHeight) {
+    std::lock_guard<std::mutex> lock(g_meshMutex);
+    g_mesh.vertices.assign(vertices, vertices + vertexCount * 5);
+    g_mesh.indices.assign(indices, indices + indexCount);
+    if (texture && texWidth > 0 && texHeight > 0) {
+        g_mesh.texture.assign(texture, texture + texWidth * texHeight);
+        g_mesh.texWidth  = texWidth;
+        g_mesh.texHeight = texHeight;
+    }
+    g_mesh.dirty = true;
+}
+
 void ShutdownOpenGL() {
     if (!g_OpenGLWindowCreated) {
         return;
@@ -127,6 +219,20 @@ void ShutdownOpenGL() {
         CloseHandle(g_renderThread);
         g_renderThread = nullptr;
     }
+
+    if (g_mesh.vbo) {
+        glDeleteBuffers(1, &g_mesh.vbo);
+        g_mesh.vbo = 0;
+    }
+    if (g_mesh.ibo) {
+        glDeleteBuffers(1, &g_mesh.ibo);
+        g_mesh.ibo = 0;
+    }
+    if (g_mesh.tex) {
+        glDeleteTextures(1, &g_mesh.tex);
+        g_mesh.tex = 0;
+    }
+
     wglMakeCurrent(nullptr, nullptr);
     if (g_hGLRC) {
         wglDeleteContext(g_hGLRC);
@@ -142,3 +248,4 @@ void ShutdownOpenGL() {
     }
     g_OpenGLWindowCreated = false;
 }
+

--- a/digi_analysis/opengl_utils.h
+++ b/digi_analysis/opengl_utils.h
@@ -1,9 +1,17 @@
 #pragma once
 #include <windows.h>
+#include <cstddef>
+#include <cstdint>
 
 // Initializes a simple OpenGL window and context.
 // Returns true on success, false on failure.
 bool InitOpenGL();
+
+// Submits a mesh to be rendered by the OpenGL render thread.  The
+// vertex format is XYZUV with 32-bit floats and indices are 16-bit.
+void SubmitMesh(const float* vertices, size_t vertexCount,
+                const uint16_t* indices, size_t indexCount,
+                const uint32_t* texture, int texWidth, int texHeight);
 
 // Tears down the OpenGL context and associated resources.
 void ShutdownOpenGL();


### PR DESCRIPTION
## Summary
- intercept D3D device creation and draw calls to capture geometry, indices, and textures
- forward captured mesh data to a new OpenGL submission path and render thread
- proxy Direct3DCreate8 to real d3d8.dll while bootstrapping the OpenGL backend

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -Ithird_party/minhook/include -c digi_analysis/d3d_capture.cpp`
- `x86_64-w64-mingw32-g++ -std=c++17 -Ithird_party/minhook/include -c digi_analysis/opengl_utils.cpp`
- `x86_64-w64-mingw32-g++ -std=c++17 -Ithird_party/minhook/include -c digi_analysis/dllmain.cpp`


------
https://chatgpt.com/codex/tasks/task_e_688af28ffe3c832f83ab7ce67ea811f2