### PR TITLE
Expand D3D8 bridge with buffer and state tracking

### DIFF
--- a/digi_analysis/d3d8_gl_bridge.cpp
+++ b/digi_analysis/d3d8_gl_bridge.cpp
@@ -53,6 +53,101 @@ const DWORD D3DFMT_INDEX16 = 101;
 const DWORD D3DFMT_INDEX32 = 102;
 
 // ---------------------------------------------------------------------------
+// IDirect3DVertexBuffer8 implementation
+// ---------------------------------------------------------------------------
+IDirect3DVertexBuffer8::IDirect3DVertexBuffer8(UINT length)
+    : m_refCount(1), m_data(length, 0), m_lockedPtr(nullptr), m_glBuffer(0), m_uploaded(false) {}
+
+IDirect3DVertexBuffer8::~IDirect3DVertexBuffer8() {
+    if (m_glBuffer) {
+        glDeleteBuffers(1, &m_glBuffer);
+    }
+}
+
+ULONG IDirect3DVertexBuffer8::AddRef() { return ++m_refCount; }
+
+ULONG IDirect3DVertexBuffer8::Release() {
+    ULONG ref = --m_refCount;
+    if (ref == 0) {
+        delete this;
+    }
+    return ref;
+}
+
+HRESULT IDirect3DVertexBuffer8::Lock(UINT OffsetToLock, UINT SizeToLock, BYTE** ppbData, DWORD) {
+    if (!ppbData) return E_POINTER;
+    if (OffsetToLock + SizeToLock > m_data.size()) return E_FAIL;
+    m_lockedPtr = m_data.data() + OffsetToLock;
+    *ppbData = m_lockedPtr;
+    return S_OK;
+}
+
+HRESULT IDirect3DVertexBuffer8::Unlock() {
+    m_lockedPtr = nullptr;
+    m_uploaded = false;
+    return S_OK;
+}
+
+void IDirect3DVertexBuffer8::Upload() {
+    if (m_uploaded) return;
+    if (!m_glBuffer) {
+        glGenBuffers(1, &m_glBuffer);
+    }
+    glBindBuffer(GL_ARRAY_BUFFER, m_glBuffer);
+    glBufferData(GL_ARRAY_BUFFER, m_data.size(), m_data.data(), GL_STATIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    m_uploaded = true;
+}
+
+// ---------------------------------------------------------------------------
+// IDirect3DIndexBuffer8 implementation
+// ---------------------------------------------------------------------------
+IDirect3DIndexBuffer8::IDirect3DIndexBuffer8(UINT length, bool use32)
+    : m_refCount(1), m_data(length, 0), m_lockedPtr(nullptr), m_glBuffer(0),
+      m_uploaded(false), m_use32(use32) {}
+
+IDirect3DIndexBuffer8::~IDirect3DIndexBuffer8() {
+    if (m_glBuffer) {
+        glDeleteBuffers(1, &m_glBuffer);
+    }
+}
+
+ULONG IDirect3DIndexBuffer8::AddRef() { return ++m_refCount; }
+
+ULONG IDirect3DIndexBuffer8::Release() {
+    ULONG ref = --m_refCount;
+    if (ref == 0) {
+        delete this;
+    }
+    return ref;
+}
+
+HRESULT IDirect3DIndexBuffer8::Lock(UINT OffsetToLock, UINT SizeToLock, BYTE** ppbData, DWORD) {
+    if (!ppbData) return E_POINTER;
+    if (OffsetToLock + SizeToLock > m_data.size()) return E_FAIL;
+    m_lockedPtr = m_data.data() + OffsetToLock;
+    *ppbData = m_lockedPtr;
+    return S_OK;
+}
+
+HRESULT IDirect3DIndexBuffer8::Unlock() {
+    m_lockedPtr = nullptr;
+    m_uploaded = false;
+    return S_OK;
+}
+
+void IDirect3DIndexBuffer8::Upload() {
+    if (m_uploaded) return;
+    if (!m_glBuffer) {
+        glGenBuffers(1, &m_glBuffer);
+    }
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_glBuffer);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_data.size(), m_data.data(), GL_STATIC_DRAW);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    m_uploaded = true;
+}
+
+// ---------------------------------------------------------------------------
 // IDirect3DTexture8 implementation
 // ---------------------------------------------------------------------------
 IDirect3DTexture8::IDirect3DTexture8(UINT width, UINT height)
@@ -121,7 +216,16 @@ HRESULT IDirect3D8::CreateDevice(UINT, DWORD, HWND, DWORD, void*, IDirect3DDevic
 // ---------------------------------------------------------------------------
 // IDirect3DDevice8 implementation
 // ---------------------------------------------------------------------------
-IDirect3DDevice8::IDirect3DDevice8() : m_refCount(1), m_currentTexture(nullptr) {}
+IDirect3DDevice8::IDirect3DDevice8()
+    : m_refCount(1), m_currentTexture(nullptr), m_streamSource(nullptr), m_streamStride(0),
+      m_indexBuffer(nullptr) {
+    // Initialise matrices to identity
+    for (int i = 0; i < 16; ++i) {
+        m_world[i]      = (i % 5 == 0) ? 1.0f : 0.0f;
+        m_view[i]       = (i % 5 == 0) ? 1.0f : 0.0f;
+        m_projection[i] = (i % 5 == 0) ? 1.0f : 0.0f;
+    }
+}
 
 ULONG IDirect3DDevice8::AddRef() {
     return ++m_refCount;
@@ -156,18 +260,127 @@ HRESULT IDirect3DDevice8::SetTexture(DWORD Stage, IDirect3DTexture8* pTexture) {
     return S_OK;
 }
 
+HRESULT IDirect3DDevice8::BeginScene() { return S_OK; }
+
+HRESULT IDirect3DDevice8::EndScene() { return S_OK; }
+
+HRESULT IDirect3DDevice8::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value) {
+    switch (State) {
+    case D3DRS_ALPHABLENDENABLE:
+        m_state.alphaBlend = (Value != 0);
+        break;
+    case D3DRS_ZENABLE:
+        m_state.depthTest = (Value != 0);
+        break;
+    default:
+        break;
+    }
+    return S_OK;
+}
+
+HRESULT IDirect3DDevice8::SetTransform(D3DTRANSFORMSTATETYPE State, const D3DMATRIX* pMatrix) {
+    if (!pMatrix) return E_POINTER;
+    switch (State) {
+    case D3DTS_WORLD:
+        std::memcpy(m_world, pMatrix->m, sizeof(m_world));
+        break;
+    case D3DTS_VIEW:
+        std::memcpy(m_view, pMatrix->m, sizeof(m_view));
+        break;
+    case D3DTS_PROJECTION:
+        std::memcpy(m_projection, pMatrix->m, sizeof(m_projection));
+        break;
+    default:
+        break;
+    }
+    return S_OK;
+}
+
+HRESULT IDirect3DDevice8::CreateVertexBuffer(UINT Length, DWORD, DWORD, DWORD,
+                               IDirect3DVertexBuffer8** ppVertexBuffer) {
+    if (!ppVertexBuffer) return E_POINTER;
+    *ppVertexBuffer = new IDirect3DVertexBuffer8(Length);
+    return S_OK;
+}
+
+HRESULT IDirect3DDevice8::CreateIndexBuffer(UINT Length, DWORD, DWORD Format, DWORD,
+                              IDirect3DIndexBuffer8** ppIndexBuffer) {
+    if (!ppIndexBuffer) return E_POINTER;
+    bool use32 = (Format == D3DFMT_INDEX32);
+    *ppIndexBuffer = new IDirect3DIndexBuffer8(Length, use32);
+    return S_OK;
+}
+
+HRESULT IDirect3DDevice8::SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer8* pStreamData,
+                            UINT Stride) {
+    if (StreamNumber != 0) return S_OK;
+    m_streamSource = pStreamData;
+    m_streamStride = Stride;
+    return S_OK;
+}
+
+HRESULT IDirect3DDevice8::SetIndices(IDirect3DIndexBuffer8* pIndexData) {
+    m_indexBuffer = pIndexData;
+    return S_OK;
+}
+
+HRESULT IDirect3DDevice8::DrawPrimitive(UINT PrimitiveType, UINT StartVertex, UINT PrimitiveCount) {
+    if (!m_streamSource) return E_FAIL;
+    PendingDraw draw;
+    draw.mode        = ToGLPrimitive(PrimitiveType);
+    draw.texture     = m_currentTexture;
+    draw.vertexBuffer = m_streamSource;
+    draw.stride      = m_streamStride;
+    draw.startVertex = StartVertex;
+    draw.vertexCount = VertexCountFromPrim(PrimitiveType, PrimitiveCount);
+    draw.state       = m_state;
+    std::memcpy(draw.world, m_world, sizeof(m_world));
+    std::memcpy(draw.view, m_view, sizeof(m_view));
+    std::memcpy(draw.projection, m_projection, sizeof(m_projection));
+    SubmitDrawCall(std::move(draw));
+    return S_OK;
+}
+
+HRESULT IDirect3DDevice8::DrawIndexedPrimitive(UINT PrimitiveType, UINT MinVertexIndex, UINT NumVertices,
+                                 UINT StartIndex, UINT PrimitiveCount) {
+    (void)MinVertexIndex;
+    if (!m_streamSource || !m_indexBuffer) return E_FAIL;
+    PendingDraw draw;
+    draw.mode         = ToGLPrimitive(PrimitiveType);
+    draw.texture      = m_currentTexture;
+    draw.vertexBuffer = m_streamSource;
+    draw.indexBuffer  = m_indexBuffer;
+    draw.stride       = m_streamStride;
+    draw.startVertex  = 0;
+    draw.vertexCount  = NumVertices;
+    draw.startIndex   = StartIndex;
+    draw.indexCount   = IndexCountFromPrim(PrimitiveType, PrimitiveCount);
+    draw.state        = m_state;
+    std::memcpy(draw.world, m_world, sizeof(m_world));
+    std::memcpy(draw.view, m_view, sizeof(m_view));
+    std::memcpy(draw.projection, m_projection, sizeof(m_projection));
+    SubmitDrawCall(std::move(draw));
+    return S_OK;
+}
+
 HRESULT IDirect3DDevice8::DrawPrimitiveUP(UINT PrimitiveType, UINT PrimitiveCount,
                                           const void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
     if (!pVertexStreamZeroData) {
         return E_POINTER;
     }
     PendingDraw draw;
-    draw.mode = ToGLPrimitive(PrimitiveType);
-    draw.texture = m_currentTexture;
+    draw.mode        = ToGLPrimitive(PrimitiveType);
+    draw.texture     = m_currentTexture;
+    draw.state       = m_state;
+    std::memcpy(draw.world, m_world, sizeof(m_world));
+    std::memcpy(draw.view, m_view, sizeof(m_view));
+    std::memcpy(draw.projection, m_projection, sizeof(m_projection));
     size_t vertCount = VertexCountFromPrim(PrimitiveType, PrimitiveCount);
     size_t strideFloats = VertexStreamZeroStride / sizeof(float);
     const float* v = static_cast<const float*>(pVertexStreamZeroData);
     draw.vertices.assign(v, v + vertCount * strideFloats);
+    draw.stride      = VertexStreamZeroStride;
+    draw.vertexCount = static_cast<UINT>(vertCount);
     SubmitDrawCall(std::move(draw));
     return S_OK;
 }
@@ -180,11 +393,17 @@ HRESULT IDirect3DDevice8::DrawIndexedPrimitiveUP(UINT PrimitiveType, UINT MinVer
         return E_POINTER;
     }
     PendingDraw draw;
-    draw.mode = ToGLPrimitive(PrimitiveType);
-    draw.texture = m_currentTexture;
+    draw.mode        = ToGLPrimitive(PrimitiveType);
+    draw.texture     = m_currentTexture;
+    draw.state       = m_state;
+    std::memcpy(draw.world, m_world, sizeof(m_world));
+    std::memcpy(draw.view, m_view, sizeof(m_view));
+    std::memcpy(draw.projection, m_projection, sizeof(m_projection));
     size_t strideFloats = VertexStreamZeroStride / sizeof(float);
     const float* v = static_cast<const float*>(pVertexStreamZeroData);
     draw.vertices.assign(v, v + NumVertices * strideFloats);
+    draw.stride      = VertexStreamZeroStride;
+    draw.vertexCount = NumVertices;
 
     size_t indexCount = IndexCountFromPrim(PrimitiveType, PrimitiveCount);
     if (IndexDataFormat == D3DFMT_INDEX16) {
@@ -199,6 +418,7 @@ HRESULT IDirect3DDevice8::DrawIndexedPrimitiveUP(UINT PrimitiveType, UINT MinVer
     } else {
         return E_FAIL;
     }
+    draw.indexCount = static_cast<UINT>(indexCount);
     SubmitDrawCall(std::move(draw));
     return S_OK;
 }

--- a/digi_analysis/opengl_utils.h
+++ b/digi_analysis/opengl_utils.h
@@ -8,7 +8,16 @@
 #include <GL/gl.h>
 #include <vector>
 
-class IDirect3DTexture8; // forward declaration
+class IDirect3DTexture8;      // forward declaration
+class IDirect3DVertexBuffer8; // forward declaration
+class IDirect3DIndexBuffer8;  // forward declaration
+
+// Minimal set of render states tracked by the bridge.  Additional states can
+// be added as needed.
+struct RenderState {
+    bool alphaBlend = false;
+    bool depthTest  = false;
+};
 
 // Basic container for draw information passed from the Direct3D
 // emulation layer to the renderer.  Vertices are expected to contain
@@ -16,10 +25,21 @@ class IDirect3DTexture8; // forward declaration
 // vertex.  Indices are optional – if empty, the vertices will be
 // rendered sequentially.
 struct PendingDraw {
-    GLenum                     mode;
-    std::vector<float>        vertices;
-    std::vector<unsigned short> indices;
-    IDirect3DTexture8*        texture;
+    GLenum                      mode;
+    RenderState                 state;
+    float                       world[16];
+    float                       view[16];
+    float                       projection[16];
+    IDirect3DTexture8*          texture;
+    IDirect3DVertexBuffer8*     vertexBuffer = nullptr;
+    IDirect3DIndexBuffer8*      indexBuffer  = nullptr;
+    std::vector<float>          vertices; // used when no vertexBuffer provided
+    std::vector<unsigned short> indices;  // used when no indexBuffer provided
+    UINT                        stride      = 0;
+    UINT                        startVertex = 0;
+    UINT                        startIndex  = 0;
+    UINT                        vertexCount = 0;
+    UINT                        indexCount  = 0;
 };
 
 // Initializes a simple OpenGL window and context.  Returns true on


### PR DESCRIPTION
## Summary
- stub out vertex and index buffer objects and expose core IDirect3DDevice8 methods to create, bind and draw with them
- track basic render state and transformation matrices and propagate them through PendingDraw to the OpenGL thread
- switch renderer to vertex/index buffer objects and apply recorded state and matrices during draw submission

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -c digi_analysis/d3d8_gl_bridge.cpp -Idigi_analysis -o /tmp/d3d8_gl_bridge.o`
- `x86_64-w64-mingw32-g++ -std=c++17 -c digi_analysis/opengl_utils.cpp -Idigi_analysis -o /tmp/opengl_utils.o`


------
https://chatgpt.com/codex/tasks/task_e_688afd6dd920832faec0dbf93c693b1d