### PR TITLE
Use GLEW for OpenGL extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # digi_vstudio
+
+This project now uses the **GLEW** library for OpenGL extension handling,
+replacing the previous reliance on the `glext` headers.

--- a/digi_analysis/main.cpp
+++ b/digi_analysis/main.cpp
@@ -5,6 +5,9 @@
 // live in functions.cpp and the extracted strings are available in strings.h.
 
 #include <windows.h>
+// Use GLEW to handle OpenGL extensions instead of relying on the older
+// glext headers.
+#include <GL/glew.h>
 #include <string>
 #include "digi_table.h"
 #include "strings.h"


### PR DESCRIPTION
## Summary
- switch project to GLEW for managing OpenGL extensions
- document GLEW usage in README

## Testing
- `g++ -c digi_analysis/main.cpp -I/usr/include` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688b0406ffdc832f971da4e99da6cff6