### PR TITLE
Replace glext with GLEW

### DIFF
--- a/digi_analysis/d3d8_gl_bridge.h
+++ b/digi_analysis/d3d8_gl_bridge.h
@@ -1,10 +1,6 @@
 #pragma once
 #include <windows.h>
-#include <GL/gl.h>
-#ifndef GL_GLEXT_PROTOTYPES
-#define GL_GLEXT_PROTOTYPES
-#endif
-#include <GL/glext.h>
+#include <GL/glew.h>
 #include <vector>
 #include <cstddef>
 #include "opengl_utils.h"

--- a/digi_analysis/opengl_utils.cpp
+++ b/digi_analysis/opengl_utils.cpp
@@ -4,11 +4,6 @@
 
 #include "opengl_utils.h"
 #include "d3d8_gl_bridge.h"
-#include <GL/gl.h>
-#ifndef GL_GLEXT_PROTOTYPES
-#define GL_GLEXT_PROTOTYPES
-#endif
-#include <GL/glext.h>
 #include <mutex>
 
 namespace {

--- a/digi_analysis/opengl_utils.h
+++ b/digi_analysis/opengl_utils.h
@@ -5,7 +5,7 @@
 
 #pragma once
 #include <windows.h>
-#include <GL/gl.h>
+#include <GL/glew.h>
 #include <vector>
 
 class IDirect3DTexture8;      // forward declaration


### PR DESCRIPTION
## Summary
- replace legacy OpenGL glext header usage with GLEW across analysis tools
- streamline OpenGL includes in helper code

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_688b05e7d614832fb895fa15bee57837